### PR TITLE
Fix infinite loop getting scoreboard rankings

### DIFF
--- a/src/net/evmodder/EvStats/ObjectivesExpansion.java
+++ b/src/net/evmodder/EvStats/ObjectivesExpansion.java
@@ -126,7 +126,7 @@ public class ObjectivesExpansion extends PlaceholderExpansion{
 			if(ss < target) high = r;
 			else if(ss > target) low = r;
 			else{
-				final int cmpE = s.getEntry().compareTo(score.getEntry());
+				final int cmpE = s.getEntry().compareToIgnoreCase(score.getEntry());
 				if(cmpE < 0) low = r;
 				else if(cmpE > 0) high = r;
 				else return r;


### PR DESCRIPTION
Since Minecraft itself sorts scoreboard entries regardless of case, we should do this too when calculating the ranking of a particular entry to avoid running into infinite loops.

## Example

On my own server, I used the tab list with PlaceholderAPI/ScoreboardObjectives to show player death counts and rankings, but someone (player name starting with **S**) would always crash either the tab plugin or the server itself on joining until they die and have their counter incremented.

After some investigation I found the scoreboard used to look like this:

[1] xxxx xxx
...
[13] Player **e** - `5`
[14] Player **S** - `5`
...
[16] *(last entry)*

[The original code](https://github.com/EvModder/EvStats/blob/37187a648e68d535ca61099d632cfd8636758d3b/src/net/evmodder/EvStats/ObjectivesExpansion.java#L122) uses a binary search to calculate the ranking and it lands on #13 player **e**. Then it tries to compare player `S`'s name with player `e`'s **case-sensitively**. Since lower cases comes after upper ones, it thinks player `e` comes after player `S` too and runs into an infinite loop, eventually crashing the server.