### PR TITLE
Fix(again) for entries with the same score

### DIFF
--- a/src/net/evmodder/EvStats/ObjectivesExpansion.java
+++ b/src/net/evmodder/EvStats/ObjectivesExpansion.java
@@ -116,6 +116,7 @@ public class ObjectivesExpansion extends PlaceholderExpansion{
 	private int getRank(final Objective obj, final Score score){
 		if(!score.isScoreSet()) return -999;
 		final int target = score.getScore();
+		final String entry = score.getEntry();
 		getScoreAtRank(obj, -1);
 		int low = 1, high = numEntries+1;
 		//int r = numEntries/2, s = getScoreAtRank(objName, r+1).getScore();
@@ -126,10 +127,17 @@ public class ObjectivesExpansion extends PlaceholderExpansion{
 			if(ss < target) high = r;
 			else if(ss > target) low = r;
 			else{
-				final int cmpE = s.getEntry().compareToIgnoreCase(score.getEntry());
-				if(cmpE < 0) low = r;
-				else if(cmpE > 0) high = r;
-				else return r;
+				if(s.getEntry().equals(entry)) return r;
+				for(int i = r + 1; i < high; ++i){
+					final Score testScore = getScoreAtRank(obj, i);
+					if(testScore.getScore() != target) break;
+					if(testScore.getEntry().equals(entry)) return i;
+				}
+				for(int i = r - 1; i > low; --i){
+					final Score testScore = getScoreAtRank(obj, i);
+					if(testScore.getScore() != target) break;
+					if(testScore.getEntry().equals(entry)) return i;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Sorry for bothering you again but actually Minecraft itself doesn't seem to use any sorting order internally (maybe because it's using HashMaps), and it only sorts case-insensitively for the sake of displaying. I have to say that I found this out the hard way after applying my supposed fix ([#4]) - my server crashed again after someone with a specific entry value joined today.

To truly fix this I have to give up on binary search for entries of the same value (it's still used for narrowing down the search range) and use linear search instead, because we can't be sure where our desired entry is without any internal order.

**Also**: maybe try assigning entries with the same score to the same ranking as the next feature? (well I'm abusing the pull request now)